### PR TITLE
Direct form

### DIFF
--- a/src/pages/ExportLaunch/index.tsx
+++ b/src/pages/ExportLaunch/index.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from "react";
 import { useSMARTContext } from "../../context/smartContext";
 import { useNavigate } from "react-router";
 import ehiExport from "../../lib/ehiExport";
-// import Button from "../../components/Button";
-// import LinkButton from "../../components/LinkButton";
+import Button from "../../components/Button";
+import LinkButton from "../../components/LinkButton";
 import ErrorMessage from "../../components/ErrorMessage";
 import Loading from "../../components/Loading";
 
@@ -12,7 +12,7 @@ export default function App() {
   const navigate = useNavigate();
   const { client, loading, error } = SMART;
   const [ehiError, setEhiError] = useState<Error | null>(null);
-  // const [ehiLink, setEhiLink] = useState<string | null>(null);
+  const [ehiLink, setEhiLink] = useState<string | null>(null);
 
   // Trigger EHI Export when there is an authorized client
   useEffect(() => {
@@ -27,8 +27,12 @@ export default function App() {
               "redirect",
               window.location.origin + "/jobs"
             );
-            // setEhiLink(String(linkWithRedirect));
-            window.location.assign(linkWithRedirect)
+
+            if (linkWithRedirect.searchParams.get("behavior") === "automatic") { // or "manual"
+              window.location.assign(linkWithRedirect)
+            } else {
+              setEhiLink(String(linkWithRedirect));
+            }
           } else {
             navigate("/jobs");
           }
@@ -62,25 +66,25 @@ export default function App() {
         error={ehiError}
       />
     );
-    // } else if (ehiLink) {
-    //   // Export succeeded, but there is additional user interaction needed
-    //   return (
-    //     <div className="mx-auto mt-4 w-full rounded border bg-white p-4">
-    //       <h1 className="mb-2 text-2xl font-bold">
-    //         Additional Information Required
-    //       </h1>
-    //       <p className="mb-8">
-    //         In order for the EHI Export request to be processed, there is an
-    //         additional form to complete.
-    //       </p>
-    //       <div className="mt-2 flex justify-between">
-    //         <LinkButton to="/jobs">Finish Later</LinkButton>
-    //         <Button autoFocus onClick={() => (window.location.href = ehiLink)}>
-    //           Complete Form
-    //         </Button>
-    //       </div>
-    //     </div>
-    //   );
+  } else if (ehiLink) {
+    // Export succeeded, but there is additional user interaction needed
+    return (
+      <div className="mx-auto mt-4 w-full rounded border bg-white p-4">
+        <h1 className="mb-2 text-2xl font-bold">
+          Additional Information Required
+        </h1>
+        <p className="mb-8">
+          In order for the EHI Export request to be processed, there is an
+          additional form to complete.
+        </p>
+        <div className="mt-2 flex justify-between">
+          <LinkButton to="/jobs">Finish Later</LinkButton>
+          <Button autoFocus onClick={() => (window.location.href = ehiLink)}>
+            Complete Form
+          </Button>
+        </div>
+      </div>
+    );
   } else {
     // Export was successful, there was no link; we should be redirecting to the main page in above effect
     return null;


### PR DESCRIPTION
Just a quick patch to render the form directly instead of asking the user. The "redirect from kick-off" approach doesn't work with Ajax POST, but this might be the next best thing.

The server will now tell you who the patient is so that we can even skip the first form login, and send you a `behavior=automatic` param to tell you to render the form without asking the user - https://github.com/smart-on-fhir/ehi-server/blob/main/lib/EHIGateway.ts#L182 
